### PR TITLE
Fix development server launch issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --max-http-header-size=8192",
+    "dev": "vite",
     "build": "tsc && vite build",
     "build-no-errors": "tsc ; vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",


### PR DESCRIPTION
Update the `npm run dev` script in `package.json` to correctly configure the development server.

* Remove the `--max-http-header-size=8192` option from the `dev` script.
* Ensure the `dev` script only contains `vite`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/patmode91/artificia-nft-collective_v2/pull/21?shareId=fa2d0a51-4de5-4695-acf0-1dd54727e3f3).