### PR TITLE
Fix vulnerabilities in request and tough-cookie dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "react-resizable-panels": "^2.0.19",
     "react-router": "^6.23.1",
     "react-router-dom": "^6.23.1",
-    "request": "^2.88.2",
     "shelljs": "^0.8.5",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
Fixes #20

Remove the vulnerable `request` package from `package.json`.

* **Dependencies**
  - Remove `request` version `2.88.2` from `package.json`
  - Keep `tough-cookie` version `4.1.3` in `package.json`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/patmode91/artificia-nft-collective_v2/pull/23?shareId=1a6297a5-aad9-4819-ae9b-e384f6598929).