### PR TITLE
Remove vulnerable utile library and replace with native util module

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "tough-cookie": "^4.1.3",
-    "utile": "^0.3.0",
     "vaul": "^0.9.1",
     "whitesource": "^18.4.2",
     "ws": "^7.5.10",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,11 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { format } from "util"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function formatString(formatStr: string, ...args: any[]): string {
+  return format(formatStr, ...args)
 }


### PR DESCRIPTION
Fixes #19

Remove the vulnerable `utile` library from the project.

* **package.json**
  - Remove the `utile` library from the `dependencies` section.

* **src/lib/utils.ts**
  - Add import for `format` from the native Node.js `util` module.
  - Add a new function `formatString` to replace the functionality previously provided by `utile`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/patmode91/artificia-nft-collective_v2/pull/24?shareId=d2f7a400-0fd3-4aaa-ba14-392ca71ce739).