### PR TITLE
Fix vulnerabilities in request and tough-cookie dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "types:supabase": "npx supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > src/types/supabase.ts"
   },
   "dependencies": {
-    "@cypress/request": "^3.0.0",
+    "@cypress/request": "^3.0.7",
     "@hookform/resolvers": "^3.6.0",
     "@huggingface/inference": "^2.8.1",
     "@radix-ui/react-accordion": "^1.1.2",
@@ -69,7 +69,6 @@
     "react-resizable-panels": "^2.0.19",
     "react-router": "^6.23.1",
     "react-router-dom": "^6.23.1",
-    "request": "^2.88.2",
     "shelljs": "^0.8.5",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
Fixes #20

Update dependencies in `package.json` to address vulnerabilities.

* **Upgrade** `@cypress/request` to version 3.0.7.
* **Remove** `request` version 2.88.2.
* **Ensure** `tough-cookie` version 4.1.3 is present.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/patmode91/artificia-nft-collective_v2/pull/25?shareId=f52897f6-8c5b-4463-82fe-e8f6f7d0de90).