### PR TITLE
Fix vulnerabilities in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tough-cookie": "^4.1.3",
     "vaul": "^0.9.1",
-    "whitesource": "^18.4.2",
+    "whitesource": "^19.7.1",
     "ws": "^7.5.10",
     "zod": "^3.23.8"
   },


### PR DESCRIPTION
Fixes #13

Update `whitesource` dependency in `package.json` to address vulnerabilities.

* Upgrade `whitesource` from version `^18.4.2` to `^19.7.1`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/patmode91/artificia-nft-collective_v2/pull/27?shareId=d6521991-fb60-4a95-89a6-6ed043ae3fe3).