### PR TITLE
Update ipfs-http-client to fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "glob-parent": "^5.1.2",
     "got": "^12.1.0",
     "hawk": "^9.0.1",
-    "ipfs-http-client": "^57.0.3",
+    "ipfs-http-client": "^57.0.4-051da161.0",
     "lucide-react": "^0.394.0",
     "micromatch": "^4.0.8",
     "nanoid": "^3.3.8",
@@ -93,5 +93,8 @@
     "tempo-devtools": "^2.0.94",
     "typescript": "^5.2.2",
     "vite": "^5.2.0"
+  },
+  "resolutions": {
+    "nanoid": "^3.3.8"
   }
 }


### PR DESCRIPTION
Fixes #12

Update `ipfs-http-client` dependency to address vulnerability.

* Change `ipfs-http-client` version to `^57.0.4-051da161.0` in `package.json`
* Add `resolutions` field in `package.json`
* Add `"nanoid": "^3.3.8"` to the `resolutions` field in `package.json`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/patmode91/artificia-nft-collective_v2/pull/34?shareId=acbae74a-6023-4bb4-b931-ada4935b57d4).