### PR TITLE
Update ipfs-http-client to resolve CVE-2025-22150 vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "glob-parent": "^5.1.2",
         "got": "^12.1.0",
         "hawk": "^9.0.1",
-        "ipfs-http-client": "^57.0.3",
+        "ipfs-http-client": "^57.0.4-051da161.0",
         "lucide-react": "^0.394.0",
         "micromatch": "^4.0.8",
         "nanoid": "^3.3.8",
@@ -5292,9 +5292,9 @@
       }
     },
     "node_modules/ipfs-core-types": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.11.1.tgz",
-      "integrity": "sha512-K7ZSx9EPEvT4At2kExKyMCqY4Jo3Nb/VnC/iSWqFKRaqb0MTB4IJgvWrwwDuN541tn+dvUnTfOp2wWQSov1UAw==",
+      "version": "0.11.2-a05695fc.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.11.2-a05695fc.0.tgz",
+      "integrity": "sha512-79XXPfg/71lcSNUE72fTfBujOLB4uzBfxKBCzwhlU410Df4P2j61YnWH1t6/jxJ9+230caT1AZU+D+I3zHtkhA==",
       "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
       "dependencies": {
         "@ipld/dag-pb": "^2.1.3",
@@ -5305,9 +5305,9 @@
       }
     },
     "node_modules/ipfs-core-utils": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.15.1.tgz",
-      "integrity": "sha512-nZmUiLctJWMFrEciVkKdDUO2xLpXWy7Ilt0VMJ35Y5+OJznCXxMHUQo1WUALATlo9ziHgDdHFrAUuyW0yB2rww==",
+      "version": "0.15.2-a05695fc.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.15.2-a05695fc.0.tgz",
+      "integrity": "sha512-dR30SwtXpPhczUv55Z/uzTBzInEXN9k+RV+ykPOSMjCfyVl8pL9AFfIzj/1Bou5NBvduM4UVcYssFLxt3E9kdw==",
       "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
       "dependencies": {
         "@libp2p/logger": "^1.1.4",
@@ -5317,7 +5317,7 @@
         "blob-to-it": "^1.0.1",
         "browser-readablestream-to-it": "^1.0.1",
         "err-code": "^3.0.1",
-        "ipfs-core-types": "^0.11.1",
+        "ipfs-core-types": "^0.11.2-a05695fc.0",
         "ipfs-unixfs": "^6.0.9",
         "ipfs-utils": "^9.0.6",
         "it-all": "^1.0.4",
@@ -5333,9 +5333,9 @@
       }
     },
     "node_modules/ipfs-http-client": {
-      "version": "57.0.3",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-57.0.3.tgz",
-      "integrity": "sha512-IOqxcMei7Y2bxU2Se98YB+HEv2rZp9aTbkQjNY4XgoeG3eMp0zU/6tpguOHzC5a6SOCojZRrcAAZq2RAwdmrhg==",
+      "version": "57.0.4-a05695fc.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-57.0.4-a05695fc.0.tgz",
+      "integrity": "sha512-r1GH/ueZJbMRZyTlxaz0pQJyFco69wavPy+/rnZ/8PvewGAOfKATeFmcf6pTV5M45Ouhx4qgiPQOhX5sVBwPUQ==",
       "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
       "dependencies": {
         "@ipld/dag-cbor": "^7.0.0",
@@ -5347,8 +5347,8 @@
         "any-signal": "^3.0.0",
         "dag-jose": "^1.0.0",
         "err-code": "^3.0.1",
-        "ipfs-core-types": "^0.11.1",
-        "ipfs-core-utils": "^0.15.1",
+        "ipfs-core-types": "^0.11.2-a05695fc.0",
+        "ipfs-core-utils": "^0.15.2-a05695fc.0",
         "ipfs-utils": "^9.0.6",
         "it-first": "^1.0.6",
         "it-last": "^1.0.4",
@@ -6387,9 +6387,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
-      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
+      "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "p-timeout": "^6.1.2"
@@ -6401,7 +6401,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-queue/node_modules/p-timeout": {
+    "node_modules/p-timeout": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
       "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
@@ -6427,9 +6427,9 @@
       }
     },
     "node_modules/parse-duration": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.1.tgz",
-      "integrity": "sha512-27m0hKqcGzYFGtrZ1FPSNuAUi1mvqYIUjHHIgYYAc+4wcj7t2o7Qj3X4s7THMOYyeTcFjmKUZu0yJG2oE947bw=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.2.tgz",
+      "integrity": "sha512-p8EIONG8L0u7f8GFgfVlL4n8rnChTt8O5FSxgxMz2tjc9FMP199wxVKVB6IbKx11uTbKHACSvaLVIKNnoeNR/A=="
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -8039,9 +8039,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },


### PR DESCRIPTION
Related to #12

Update `ipfs-http-client` dependency to resolve CVE-2025-22150 vulnerability.

* Update `ipfs-http-client` version to `^57.0.4-051da161.0` in `package-lock.json`.
* Update `ipfs-core-types` version to `0.11.2-a05695fc.0` in `package-lock.json`.
* Update `ipfs-core-utils` version to `0.15.2-a05695fc.0` in `package-lock.json`.
* Update `undici` version to `5.28.5` in `package-lock.json`.
* Update `p-queue` version to `8.1.0` in `package-lock.json`.
* Update `parse-duration` version to `1.1.2` in `package-lock.json`.
* Remove nested `p-timeout` dependency in `package-lock.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/patmode91/artificia-nft-collective_v2/pull/35?shareId=898bab3c-c98e-4072-82bf-f8082212c711).